### PR TITLE
Adding a workdir flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,7 @@ LABEL maintainer="Rob Bell"
 ARG PLANTUML_VERSION=1.2020.0
 RUN apk add --no-cache graphviz wget ttf-dejavu && \
   wget "http://sourceforge.net/projects/plantuml/files/plantuml.${PLANTUML_VERSION}.jar/download" -O plantuml.jar
-ENTRYPOINT ["java", "-jar", "plantuml.jar"]
+WORKDIR /source/
+ENTRYPOINT ["java", "-jar", "/plantuml.jar"]
+
 CMD ["-p"]


### PR DESCRIPTION
this make your command from:
`docker run -v path-to-mount:/source --rm -i robbell/plantuml-docker source/*.puml`
`docker run -v path-to-mount:/source --rm -i robbell/plantuml-docker ./*.puml`
and this makes easier to implement a bash or zsh alias like:
`docker run -v  $(pwd):/source --rm -i robbell/plantuml-docker ./*.puml`